### PR TITLE
repository.debs small fix

### DIFF
--- a/repository.debs
+++ b/repository.debs
@@ -35,5 +35,5 @@ if [ $INSTALL_PACKAGES != false ]; then
 fi
 
 ### install further repositories
-rosinstall .. /opt/ros/indigo repository.rosinstall
+rosinstall .. /opt/ros/kinetic repository.rosinstall
 


### PR DESCRIPTION
rosinstall was trying to install further repositories with /opt/ros/indigo instead of /opt/ros/kinetic. 