### PR TITLE
[mcr_manipulation_utils] -> urdf::Joint**SharedPtr

### DIFF
--- a/mcr_manipulation/mcr_manipulation_utils/ros/include/mcr_manipulation_utils/ros_urdf_loader.h
+++ b/mcr_manipulation/mcr_manipulation_utils/ros/include/mcr_manipulation_utils/ros_urdf_loader.h
@@ -25,7 +25,7 @@ public:
                    const std::string &root_name,
                    const std::string &tip_name,
                    KDL::Chain& out_arm,
-                   std::vector<boost::shared_ptr<urdf::JointLimits> >& out_joint_limits);
+                   std::vector<urdf::JointLimitsSharedPtr >& out_joint_limits);
 
 };
 

--- a/mcr_manipulation/mcr_manipulation_utils/ros/src/ros_urdf_loader.cpp
+++ b/mcr_manipulation/mcr_manipulation_utils/ros/src/ros_urdf_loader.cpp
@@ -24,7 +24,7 @@ bool ROS_URDF_Loader::loadModel(ros::NodeHandle& node_handle,
                                 const std::string &root_name,
                                 const std::string &tip_name,
                                 KDL::Chain& out_arm,
-                                std::vector<boost::shared_ptr<urdf::JointLimits> >& out_joint_limits)
+                                std::vector<urdf::JointLimitsSharedPtr >& out_joint_limits)
 {
     urdf::Model robot_model;
 
@@ -68,7 +68,7 @@ bool ROS_URDF_Loader::loadModel(ros::NodeHandle& node_handle,
 
         std::string name = out_arm.getSegment(i).getJoint().getName();
 
-        boost::shared_ptr<const urdf::Joint> joint = robot_model.getJoint(name);
+        urdf::JointConstSharedPtr joint = robot_model.getJoint(name);
 
         out_joint_limits.push_back(joint->limits);
 


### PR DESCRIPTION
This fixes compiling on Melodic and I believe it should be backwards compatible as far back as Indigo.