### PR TITLE
[pluginlib] replace deprecated macros and headers

### DIFF
--- a/mcr_common/mcr_topic_tools/ros/include/mcr_topic_tools/topic_mux.h
+++ b/mcr_common/mcr_topic_tools/ros/include/mcr_topic_tools/topic_mux.h
@@ -34,7 +34,7 @@
 #define MCR_TOPIC_TOOLS_TOPIC_MUX_H_
 
 #include <nodelet/nodelet.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <ros/ros.h>
 #include <std_msgs/String.h>
 #include <string>
@@ -143,7 +143,7 @@ private:
     ros::Subscriber sub_event_in_;
     ros::Publisher pub_event_out_;
 };
-PLUGINLIB_DECLARE_CLASS(mcr_topic_tools, TopicMux, mcr_topic_tools::TopicMux, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS( mcr_topic_tools::TopicMux, nodelet::Nodelet);
 } /* namespace mcr_topic_tools */
 
 #endif  // MCR_TOPIC_TOOLS_TOPIC_MUX_H_

--- a/mcr_controllers/mcr_multi_joint_forward_controller/ros/src/multi_joint_forward_controller.cpp
+++ b/mcr_controllers/mcr_multi_joint_forward_controller/ros/src/multi_joint_forward_controller.cpp
@@ -1,6 +1,6 @@
 #include <mcr_multi_joint_forward_controller/multi_joint_forward_controller.h>
 
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 
 
 namespace position_controllers

--- a/mcr_monitoring/mcr_node_diagnostic/ros/include/mcr_node_diagnostic/analyser/mcr_node_analyzer.h
+++ b/mcr_monitoring/mcr_node_diagnostic/ros/include/mcr_node_diagnostic/analyser/mcr_node_analyzer.h
@@ -12,7 +12,7 @@
 #include <diagnostic_aggregator/analyzer.h>
 #include <diagnostic_aggregator/status_item.h>
 #include <diagnostic_msgs/DiagnosticStatus.h>
-#include <pluginlib/class_list_macros.h>
+#include <pluginlib/class_list_macros.hpp>
 #include <string>
 
 namespace diagnostic_aggregator

--- a/mcr_monitoring/mcr_node_diagnostic/ros/src/mcr_node_analyzer.cpp
+++ b/mcr_monitoring/mcr_node_diagnostic/ros/src/mcr_node_analyzer.cpp
@@ -11,9 +11,8 @@
 
 using namespace std;
 
-PLUGINLIB_REGISTER_CLASS(mcr_node_analyzer,
-                         diagnostic_aggregator::mcr_node_analyzer,
-                         diagnostic_aggregator::Analyzer)
+PLUGINLIB_EXPORT_CLASS(diagnostic_aggregator::mcr_node_analyzer,
+                       diagnostic_aggregator::Analyzer)
 
 namespace diagnostic_aggregator
 {


### PR DESCRIPTION
The macros have been deprecated since ROS Groovy.
http://wiki.ros.org/pluginlib#pluginlib.2BAC8-pluginlib_groovy.Changes_from_Pre-Groovy_pluginlib

That migration script isn't even available anymore:
`wget https://raw.githubusercontent.com/ros/pluginlib/groovy-devel/bin/plugin_macro_update`

The new headers have been backported to Indigo, Kinetic & Melodic... or at least the migration script has
https://github.com/ros/pluginlib/pull/104