### PR TITLE
add -std=c++11 flag, fix compile errors

### DIFF
--- a/mcr_manipulation/mcr_arm_cartesian_control/CMakeLists.txt
+++ b/mcr_manipulation/mcr_arm_cartesian_control/CMakeLists.txt
@@ -1,9 +1,10 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(mcr_arm_cartesian_control)
 add_compile_options(
-    # Code optimization level 3 (-O3). Diable this flag for compiling in debug mode or in case of unexpected crashing. 
-	  -O3 
-	    )
+    # Code optimization level 3 (-O3). Diable this flag for compiling in debug mode or in case of unexpected crashing.
+    -O3
+    -std=c++11
+)
 find_package(catkin REQUIRED
   COMPONENTS
     cmake_modules
@@ -18,13 +19,13 @@ find_package(Eigen3 REQUIRED)
 find_package(orocos_kdl REQUIRED)
 
 catkin_package(
-  CATKIN_DEPENDS  
+  CATKIN_DEPENDS
     mcr_manipulation_utils
     sensor_msgs
 )
 
 include_directories(
- ${PROJECT_SOURCE_DIR}/ros/include 
+ ${PROJECT_SOURCE_DIR}/ros/include
  ${PROJECT_SOURCE_DIR}/common/include
  ${EIGEN_INCLUDE_DIRS}
  ${catkin_INCLUDE_DIRS}
@@ -33,13 +34,13 @@ include_directories(
 add_executable(arm_cartesian_control
   ros/src/arm_cartesian_control_node.cpp
   common/src/arm_cartesian_control.cpp)
-    
+
 target_link_libraries(arm_cartesian_control
-  ${catkin_LIBRARIES} 
-  ${orocos_kdl_LIBRARIES}  
+  ${catkin_LIBRARIES}
+  ${orocos_kdl_LIBRARIES}
 )
 
-add_dependencies(arm_cartesian_control 
+add_dependencies(arm_cartesian_control
   ${catkin_EXPORTED_TARGETS}
 )
 

--- a/mcr_manipulation/mcr_arm_cartesian_control/ros/src/arm_cartesian_control_node.cpp
+++ b/mcr_manipulation/mcr_arm_cartesian_control/ros/src/arm_cartesian_control_node.cpp
@@ -205,7 +205,7 @@ void publishJointVelocities(KDL::JntArrayVel& joint_velocities)
         jointMsg.velocities[i].value = joint_velocities.qdot(i);
         ROS_DEBUG("%s: %.5f %s", jointMsg.velocities[i].joint_uri.c_str(),
                   jointMsg.velocities[i].value, jointMsg.velocities[i].unit.c_str());
-        if (isnan(jointMsg.velocities[i].value))
+        if (std::isnan(jointMsg.velocities[i].value))
         {
             ROS_ERROR("invalid joint velocity: nan");
             return;
@@ -227,7 +227,7 @@ void publishJointVelocities_FA(KDL::JntArrayVel& joint_velocities)
     for (unsigned int i = 0; i < joint_velocities.qdot.rows(); i++)
     {
         joint_velocitiy_array.data.push_back(joint_velocities.qdot(i));
-        if (isnan(joint_velocities.qdot(i)))
+        if (std::isnan(joint_velocities.qdot(i)))
         {
             ROS_ERROR("invalid joint velocity: nan");
             return;

--- a/mcr_manipulation/mcr_arm_cartesian_control/ros/src/ros_arm_cartesian_control.cpp
+++ b/mcr_manipulation/mcr_arm_cartesian_control/ros/src/ros_arm_cartesian_control.cpp
@@ -134,7 +134,7 @@ void RosArmCartesianControl::publishJointVelocities(KDL::JntArrayVel& joint_velo
         jointMsg.velocities[i].value = joint_velocities.qdot(i);
         ROS_DEBUG("%s: %.5f %s", jointMsg.velocities[i].joint_uri.c_str(),
                   jointMsg.velocities[i].value, jointMsg.velocities[i].unit.c_str());
-        if (isnan(jointMsg.velocities[i].value))
+        if (std::isnan(jointMsg.velocities[i].value))
         {
             ROS_ERROR("invalid joint velocity: nan");
             return;


### PR DESCRIPTION
---
name: enable C++ 11 compiler flag
---

## Changelog
<!-- Add a list of bullets with the summary of your changes -->
* add `-std=c++11` to `CMakeLists.txt`
* change `isnan` to `std::isnan` to fix compile errors

@sthoduka @abhishek098 `std::isnan` is the correct call here right?