### PR TITLE
Remove confusing unused variable in mcr_arm_cartesian_control

### DIFF
--- a/mcr_manipulation/mcr_arm_cartesian_control/common/src/arm_cartesian_control.cpp
+++ b/mcr_manipulation/mcr_arm_cartesian_control/common/src/arm_cartesian_control.cpp
@@ -127,7 +127,7 @@ void Arm_Cartesian_Control::process(
 
     ik_solver->CartToJnt(joint_positions, targetVelocity, jntVel);
     sigma.resize(arm_chain->getNrOfJoints());
-    int error_sigma = ((KDL::ChainIkSolverVel_wdls*) ik_solver)->getSigma(sigma);
+    ((KDL::ChainIkSolverVel_wdls*) ik_solver)->getSigma(sigma);
 
     // limit joint velocitied
     if (jntVel.data.norm() > 0.01)


### PR DESCRIPTION
As discussed with @alex-mitrevski, the unused variable `error_sigma` which was not required and causing confusion has been removed. The function call `getSigma` is however required as it is responsible for populating the `sigma` vector.

## Changelog
<!-- Add a list of bullets with the summary of your changes -->
<!-- Try to use infinitives: Fix, Remove, Rename, Add, Refactor -->

* Removed unused variable that was causing confusion

Related to #44 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code doesn't contain unnecessary comment blocks (e.g. unused code, templates of `package.xml` or `CMakeLists.txt`)
- [x] I have updated the `package.xml` and `CMakeLists.txt` with the correct dependencies.
- [x] I have updated the documentation accordingly.

<!-- Click on the preview button to make sure everything is correctly formatted -->
