### PR TITLE
Fixed crash when a fixed joint is part of chain

### DIFF
--- a/mcr_manipulation/mcr_arm_cartesian_control/ros/src/arm_cartesian_control_node.cpp
+++ b/mcr_manipulation/mcr_arm_cartesian_control/ros/src/arm_cartesian_control_node.cpp
@@ -189,7 +189,7 @@ void init_joint_msgs()
 {
     joint_positions_initialized.resize(arm_chain.getNrOfJoints(), false);
     jointMsg.velocities.resize(arm_chain.getNrOfJoints());
-    for (unsigned int i = 0; i < arm_chain.getNrOfSegments(); i++)
+    for (unsigned int i = 0; i < arm_chain.getNrOfJoints(); i++)
     {
         jointMsg.velocities[i].joint_uri =
             arm_chain.getSegment(i).getJoint().getName();


### PR DESCRIPTION
When a fixed joint is part of the chain then the `init_msg` crashes because that function tries to create a message to control that fixed joint. When using youbot, we were adding `gripper_static_grasp_link` at the tip of the gripper which is connected with `arm_link_5` with a static joint. This resulted in the chain having 5 joints and 6 segments. 


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code doesn't contain unnecessary comment blocks (e.g. unused code, templates of `package.xml` or `CMakeLists.txt`)
- [x] I have updated the `package.xml` and `CMakeLists.txt` with the correct dependencies.
- [x] I have updated the documentation accordingly.

<!-- Click on the preview button to make sure everything is correctly formatted -->

cc @abhishek098 