### PR TITLE
Fixed catkin build error by changing to urdf pointer type

### DIFF
--- a/mcr_manipulation/mcr_arm_cartesian_control/ros/src/arm_cartesian_control_node.cpp
+++ b/mcr_manipulation/mcr_arm_cartesian_control/ros/src/arm_cartesian_control_node.cpp
@@ -22,7 +22,7 @@
 #include <std_msgs/Float32MultiArray.h>
 
 KDL::Chain arm_chain;
-std::vector<std::shared_ptr<urdf::JointLimits> > joint_limits;
+std::vector<urdf::JointLimitsSharedPtr> joint_limits;
 
 KDL::JntArray joint_positions;
 std::vector<bool> joint_positions_initialized;


### PR DESCRIPTION
Catkin build error due to incompatible data type for joint_limits in function call `loader.loadModel(node_handle, root_name, tooltip_name, arm_chain, joint_limits);`
Changed the type of joint_limits from `std::shared_ptr<urdf::JointLimits>` to `<urdf::JointLimitsSharedPtr>` based on the function declaration in ros_urdf_loader.h

## Changelog
* Changed the variable type for joint_limits in arm_cartesian_control_node.cpp

Related to PR #70 

## Checklist:
- [x] My code doesn't contain unnecessary comment blocks (e.g. unused code, templates of `package.xml` or `CMakeLists.txt`)
