### PR TITLE
[moveit commander gui] fix import of QtWidgets; use srdfdom to get list of groups and group states

### DIFF
--- a/mcr_tools/mcr_moveit_commander_gui/CMakeLists.txt
+++ b/mcr_tools/mcr_moveit_commander_gui/CMakeLists.txt
@@ -5,6 +5,7 @@ find_package(catkin REQUIRED COMPONENTS
   roslint
   rospy
   rqt_gui_py
+  srdfdom
 )
 
 catkin_python_setup()

--- a/mcr_tools/mcr_moveit_commander_gui/package.xml
+++ b/mcr_tools/mcr_moveit_commander_gui/package.xml
@@ -16,6 +16,7 @@
   <run_depend>rospy</run_depend>
   <run_depend>rqt_gui</run_depend>
   <run_depend>rqt_gui_py</run_depend>
+  <run_depend>srdfdom</run_depend>
 
   <export>
     <rqt_gui plugin="${prefix}/plugin.xml"/>

--- a/mcr_tools/mcr_moveit_commander_gui/ros/src/mcr_moveit_commander_gui/moveit_commander_plugin.py
+++ b/mcr_tools/mcr_moveit_commander_gui/ros/src/mcr_moveit_commander_gui/moveit_commander_plugin.py
@@ -4,7 +4,7 @@ import rospkg
 
 from qt_gui.plugin import Plugin
 from python_qt_binding import loadUi
-from python_qt_binding.QtGui import QWidget
+from python_qt_binding.QtWidgets import QWidget
 from moveit_commander_widget import MoveitCommanderWidget
 
 import yaml


### PR DESCRIPTION

## Changelog
* fix import of QtWidgets
* replace regex with srdfdom for getting moveit groups and group states

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code doesn't contain unnecessary comment blocks (e.g. unused code, templates of `package.xml` or `CMakeLists.txt`)
- [x] I have updated the `package.xml` and `CMakeLists.txt` with the correct dependencies.
- [x] I have updated the documentation accordingly.

