### PR TITLE
[mcr_arm_cartesian_control] Fix handling of uninitialised and/or virtual joints

### DIFF
--- a/mcr_manipulation/mcr_arm_cartesian_control/common/src/arm_cartesian_control.cpp
+++ b/mcr_manipulation/mcr_arm_cartesian_control/common/src/arm_cartesian_control.cpp
@@ -48,6 +48,10 @@ void Arm_Cartesian_Control::checkLimits(
         double upper_limit = this->upper_joint_limits[i];
         double lower_limit = this->lower_joint_limits[i];
 
+        // skip the joint if the upper and lower limits are the same
+        if (fabs(upper_limit - lower_limit) < 1e-5)
+            continue;
+
         double upper_clearance = upper_limit - fpos;
         double lower_clearance = lower_limit - fpos;
 

--- a/mcr_manipulation/mcr_arm_cartesian_control/ros/src/arm_cartesian_control_node.cpp
+++ b/mcr_manipulation/mcr_arm_cartesian_control/ros/src/arm_cartesian_control_node.cpp
@@ -100,18 +100,26 @@ void ccCallback(geometry_msgs::TwistStampedConstPtr desiredVelocity)
 {
     // ignore the request if none of the joints have been initialised
     bool all_joints_uninitialised = true;
+    std::string uninitialized_joints = "";
     for (size_t i = 0; i < joint_positions_initialized.size(); i++)
     {
         if (joint_positions_initialized[i])
         {
             all_joints_uninitialised = false;
-            break;
         }
+        else
+        {
+            uninitialized_joints += std::to_string(i) + ", " ;
+        }
+    }
+    if (!uninitialized_joints.empty())
+    {
+        ROS_WARN_THROTTLE(5,"Joint(s) %s not initialised", uninitialized_joints.c_str());
     }
 
     if (all_joints_uninitialised)
     {
-        std::cout << "Joints not initialized; ignoring request" << std::endl;
+        ROS_ERROR("Joints not initialized; ignoring request");
         return;
     }
 

--- a/mcr_manipulation/mcr_arm_cartesian_control/ros/src/arm_cartesian_control_node.cpp
+++ b/mcr_manipulation/mcr_arm_cartesian_control/ros/src/arm_cartesian_control_node.cpp
@@ -98,14 +98,21 @@ void wjsCallback(std_msgs::Float32MultiArray weights)
 
 void ccCallback(geometry_msgs::TwistStampedConstPtr desiredVelocity)
 {
-
+    // ignore the request if none of the joints have been initialised
+    bool all_joints_uninitialised = true;
     for (size_t i = 0; i < joint_positions_initialized.size(); i++)
     {
-        if (!joint_positions_initialized[i])
+        if (joint_positions_initialized[i])
         {
-            std::cout << "joints not initialized" << std::endl;
-            return;
+            all_joints_uninitialised = false;
+            break;
         }
+    }
+
+    if (all_joints_uninitialised)
+    {
+        std::cout << "Joints not initialized; ignoring request" << std::endl;
+        return;
     }
 
     if (!tf_listener) return;


### PR DESCRIPTION
### Summary of changes

This PR introduces two small changes to `mcr_arm_cartesian_control`:
1. In the existing version, the controller ignores commands if there is at least one joint in the kinematic chain that has not been initialised (i.e. if no state information for that joint has been received). This prevents one from controlling other joints, even if they have been initialised. The new version ignores commands only if *none* of the joints have been initialised.
2. In the function that checks whether the joint limits have been reached, joints for which the lower and upper limit are equal are now skipped; for such joints, this change suppresses a constant warning message that a joint limit has been reached.

### Need for the changes

The changes address issues I have faced with the HSR, where the last joint in the chain is a virtual joint for which there is no state information and whose lower and upper limits are both set to 0. With the changes, I can control the arm despite the "invalid" last joint.

### Note

I am targeting `kinetic` with the PR, but the changes should also be merged in `melodic` and `noetic`.