### PR TITLE
Fixed urdf parsing deprecated warning

### DIFF
--- a/mcr_common/mcr_description/urdf/motors/dynamixel_motor_ax-12a.transmission.xacro
+++ b/mcr_common/mcr_description/urdf/motors/dynamixel_motor_ax-12a.transmission.xacro
@@ -10,7 +10,6 @@
     <transmission name="${name}_trans">
       <type>transmission_interface/SimpleTransmission</type>
       <actuator name="${name}_motor">
-        <hardwareInterface>EffortJointInterface</hardwareInterface>
         <mechanicalReduction>1</mechanicalReduction>
       </actuator>
       <joint name="${name}_joint">


### PR DESCRIPTION
<!--- Make the title descriptive! Provide a general summary of your changes in the title above -->
While parsing urdf, certain tags and attributes were causing the parser to print warnings regarding deprecation.

Source:
http://wiki.ros.org/urdf/XML/Transmission#A.3Ctransmission.3E_Elements
ros/urdf_parser_py#6 (comment)


## Changelog
<!-- Add a list of bullets with the summary of your changes -->
<!-- Try to use infinitives: Fix, Remove, Rename, Add, Refactor -->

- commented hardwareInterface tag in actuator for dynamixel motor transmission file

## Related PRs
<!-- Mention any other pull requests that need to be merged (and in which order, if applicable). -->
<!--If your PR is related to an issue, you can close the issue by using keywords: https://help.github.com/en/articles/closing-issues-using-keywords -->
<!-- For example, just write: Closes #31 -->

Related to https://github.com/mas-group/youbot_description/pull/10

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code doesn't contain unnecessary comment blocks (e.g. unused code, templates of `package.xml` or `CMakeLists.txt`)
- [x] I have updated the `package.xml` and `CMakeLists.txt` with the correct dependencies.
- [x] I have updated the documentation accordingly.

<!-- Click on the preview button to make sure everything is correctly formatted -->
