### PR TITLE
warnings_stating_virtual_joint_numbers_is_added

### DIFF
--- a/mcr_manipulation/mcr_arm_cartesian_control/ros/src/arm_cartesian_control_node.cpp
+++ b/mcr_manipulation/mcr_arm_cartesian_control/ros/src/arm_cartesian_control_node.cpp
@@ -100,18 +100,26 @@ void ccCallback(geometry_msgs::TwistStampedConstPtr desiredVelocity)
 {
     // ignore the request if none of the joints have been initialised
     bool all_joints_uninitialised = true;
+    std::string uninitialized_joints = "";
     for (size_t i = 0; i < joint_positions_initialized.size(); i++)
     {
         if (joint_positions_initialized[i])
         {
             all_joints_uninitialised = false;
-            break;
         }
+        else
+        {
+            uninitialized_joints += std::to_string(i) + ", " ;
+        }
+    }
+    if (!uninitialized_joints.empty())
+    {
+        ROS_WARN_THROTTLE(5,"Joint(s) %s not initialised", uninitialized_joints.c_str());
     }
 
     if (all_joints_uninitialised)
     {
-        std::cout << "Joints not initialized; ignoring request" << std::endl;
+        ROS_ERROR("Joints not initialized; ignoring request");
         return;
     }
 


### PR DESCRIPTION
## Changelog
* all numbers of the uninitialized joints are stored as a string and is printed in the log as a throttle msg with a 5 seconds interval
