### PR TITLE
Fixed Attribute error in 'Position IK request'

### DIFF
--- a/mcr_manipulation/mcr_manipulation_measurers/ros/src/mcr_manipulation_measurers_ros/pose_transformer.py
+++ b/mcr_manipulation/mcr_manipulation_measurers/ros/src/mcr_manipulation_measurers_ros/pose_transformer.py
@@ -69,6 +69,6 @@ class PoseTransformer(object):
 
             return transformed_pose
 
-        except tf.Exception, error:
+        except tf.Exception as error:
             rospy.logwarn("Exception occurred: {0}".format(error))
             return None

--- a/mcr_manipulation/mcr_manipulation_utils/ros/src/mcr_manipulation_utils_ros/kinematics.py
+++ b/mcr_manipulation/mcr_manipulation_utils/ros/src/mcr_manipulation_utils_ros/kinematics.py
@@ -75,7 +75,6 @@ class Kinematics:
 
         req = moveit_msgs.srv.GetPositionIKRequest()
         req.ik_request.timeout = rospy.Duration(timeout)
-        req.ik_request.attempts = attempts
         req.ik_request.group_name = self.group_name
         req.ik_request.robot_state.joint_state.name = self.joint_names
         req.ik_request.robot_state.joint_state.position = configuration


### PR DESCRIPTION
In noetic moveit_msgs/PositionIKRequest, there is no definition of int32 attempts. so the line ' req.ik_request.attempts = attempts ' is removed and attempts is not used anywhere

<!--- Make the title descriptive! Provide a general summary of your changes in the title above -->

## Changelog
<!-- Add a list of bullets with the summary of your changes -->
<!-- Try to use infinitives: Fix, Remove, Rename, Add, Refactor -->

* ...
* ...

## Related PRs
<!-- Mention any other pull requests that need to be merged (and in which order, if applicable). -->
<!--If your PR is related to an issue, you can close the issue by using keywords: https://help.github.com/en/articles/closing-issues-using-keywords -->
<!-- For example, just write: Closes #31 -->

Closes #XX  
Related to #YY

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code doesn't contain unnecessary comment blocks (e.g. unused code, templates of `package.xml` or `CMakeLists.txt`)
- [ ] I have updated the `package.xml` and `CMakeLists.txt` with the correct dependencies.
- [ ] I have updated the documentation accordingly.

<!-- Click on the preview button to make sure everything is correctly formatted -->
